### PR TITLE
Fix link to c-bindings README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,13 +146,13 @@ Mutation testing is work-in-progress; any contribution there would be warmly wel
 C/C++ Bindings
 --------------
 
-You can learn more about the C/C++ bindings that are made available by reading the
-[C/C++ Bindings README](lightning-c-bindings/README.md). If you are not using the C/C++ bindings,
-you likely don't need to worry about them, and during their early experimental phase we are not
-requiring that pull requests keep the bindings up to date (and, thus, pass the bindings_check CI
-run). If you wish to ensure your PR passes the bindings generation phase, you should run the
-`genbindings.sh` script in the top of the directory tree to generate, build, and test C bindings on
-your local system.
+You can learn more about the C/C++ bindings that are made available by reading the [C/C++ Bindings
+README](https://github.com/lightningdevkit/ldk-c-bindings/blob/main/lightning-c-bindings/README.md).
+If you are not using the C/C++ bindings, you likely don't need to worry about them, and during their
+early experimental phase we are not requiring that pull requests keep the bindings up to date (and,
+thus, pass the bindings_check CI run). If you wish to ensure your PR passes the bindings generation
+phase, you should run the `genbindings.sh` script in the top of the directory tree to generate,
+build, and test C bindings on your local system.
 
 Going further
 -------------


### PR DESCRIPTION
The c-bindings code was moved to a different repo:
https://github.com/lightningdevkit/ldk-c-bindings